### PR TITLE
refactor: migrate AI layer to Vercel AI SDK for multi-provider support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -67,7 +67,9 @@
       "Read(//Users/ashakirzianov/repos/booqs/**)",
       "Bash(fi)",
       "Bash(while IFS= read -r file)",
-      "Bash(then if:*)"
+      "Bash(then if:*)",
+      "Bash(npm ls:*)",
+      "Bash(npm uninstall:*)"
     ]
   },
   "enableAllProjectMcpServers": false

--- a/backend/ai.ts
+++ b/backend/ai.ts
@@ -1,25 +1,36 @@
-import OpenAI from 'openai'
+import { generateText, streamText } from 'ai'
+import { createOpenAI } from '@ai-sdk/openai'
+import { createAnthropic } from '@ai-sdk/anthropic'
 
-const AI_MODEL = 'o4-mini'
+type AiProvider = 'openai' | 'anthropic'
+
+const AI_PROVIDER: AiProvider = (process.env.AI_PROVIDER as AiProvider) ?? 'openai'
+
+function getModel() {
+    switch (AI_PROVIDER) {
+        case 'anthropic': {
+            const anthropic = createAnthropic({
+                apiKey: process.env.ANTHROPIC_API_KEY,
+            })
+            return anthropic('claude-haiku-4-5')
+        }
+        case 'openai':
+        default: {
+            const openai = createOpenAI({
+                apiKey: process.env.OPENAI_API_KEY,
+            })
+            return openai('o4-mini')
+        }
+    }
+}
 
 export async function getResponse(input: string) {
-    const openai = new OpenAI({
-        apiKey: process.env.OPENAI_API_KEY,
-    })
     try {
-        const response = await openai.responses.create({
-            model: AI_MODEL,
-            input,
+        const { text } = await generateText({
+            model: getModel(),
+            prompt: input,
         })
-        if (response.error) {
-            return {
-                success: false as const,
-                error: {
-                    message: response.error.message,
-                    code: response.error.code,
-                },
-            }
-        } else if (!response.output_text) {
+        if (!text) {
             return {
                 success: false as const,
                 error: {
@@ -30,7 +41,7 @@ export async function getResponse(input: string) {
         }
         return {
             success: true as const,
-            output: response.output_text,
+            output: text,
         }
     } catch (e) {
         console.error('getResponse', e)
@@ -45,33 +56,16 @@ export async function getResponse(input: string) {
 }
 
 export async function getStreamingResponse(input: string) {
-    const openai = new OpenAI({
-        apiKey: process.env.OPENAI_API_KEY,
-    })
-
-    const response = await openai.responses.create({
-        model: AI_MODEL,
-        input,
-        stream: true,
+    const result = streamText({
+        model: getModel(),
+        prompt: input,
     })
     const encoder = new TextEncoder()
     const stream = new ReadableStream({
         async start(controller) {
             try {
-                for await (const event of response) {
-                    if (event.type === 'error') {
-                        controller.close()
-                        return
-                    }
-
-                    if (event.type === 'response.failed') {
-                        controller.close()
-                        return
-                    }
-
-                    if (event.type === 'response.output_text.delta') {
-                        controller.enqueue(encoder.encode(event.delta))
-                    }
+                for await (const delta of result.textStream) {
+                    controller.enqueue(encoder.encode(delta))
                 }
                 controller.close()
             } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "booqs",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.69",
+        "@ai-sdk/openai": "^3.0.52",
         "@as-integrations/next": "^4.1.0",
         "@aws-sdk/client-s3": "^3.772.0",
         "@aws-sdk/s3-request-presigner": "^3.1016.0",
@@ -22,7 +24,7 @@
         "@upstash/redis": "^1.36.3",
         "@vercel/speed-insights": "^2.0.0",
         "@welldone-software/why-did-you-render": "^10.0.1",
-        "ai": "^5.0.50",
+        "ai": "^6.0.158",
         "body-parser": "^1.20.3",
         "booqs-epub": "^1.1.2",
         "clipboard-polyfill": "^4.1.1",
@@ -49,7 +51,6 @@
         "lru-cache": "^11.2.7",
         "nanoid": "^5.1.5",
         "next": "^16.1.6",
-        "openai": "^5.10.2",
         "postcss": "^8.5.3",
         "postcss-prefix-selector": "^2.1.1",
         "postcss-selector-parser": "^7.1.0",
@@ -106,14 +107,30 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.54",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.54.tgz",
-      "integrity": "sha512-bK47JS1IYanXc5ruhfEVLDUcig7Im3gQr5p52AB4x//mT/wcGLf85SxwGWzw42pyOsW8ee38Wy567WWJc90s/A==",
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.69",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
+      "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.22",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.95",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.95.tgz",
+      "integrity": "sha512-ZmUNNbZl3V42xwQzPaNUi+s8eqR2lnrxf0bvB6YbLXpLjHYv0k2Y78t12cNOfY0bxGeuVVTLyk856uLuQIuXEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
         "@vercel/oidc": "3.1.0"
       },
       "engines": {
@@ -123,10 +140,26 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.52",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.52.tgz",
+      "integrity": "sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
-      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -136,13 +169,13 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.22.tgz",
-      "integrity": "sha512-fFT1KfUUKktfAFm5mClJhS1oux9tP2qgzmEZVl5UdwltQ1LO/s8hd7znVrgKzivwv1s1FIPza0s9OpJaNB/vHw==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@standard-schema/spec": "^1.0.0",
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
         "eventsource-parser": "^3.0.6"
       },
       "engines": {
@@ -7835,14 +7868,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.149",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.149.tgz",
-      "integrity": "sha512-ebOvqbUZ4njabaKC7gpuFBbNsyvH8y/9eyIDgKefu9PB8j5GdkWKsXNtPxhz4PDFnDb0GClCtsJ4j/gWy71UNg==",
+      "version": "6.0.158",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.158.tgz",
+      "integrity": "sha512-gLTp1UXFtMqKUi3XHs33K7UFglbvojkxF/aq337TxnLGOhHIW9+GyP2jwW4hYX87f1es+wId3VQoPRRu9zEStQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.54",
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.22",
+        "@ai-sdk/gateway": "3.0.95",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -15514,27 +15547,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openai": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.10.2.tgz",
-      "integrity": "sha512-n+vi74LzHtvlKcDPn9aApgELGiu5CwhaLG40zxLTlFQdoSJCLACORIPC2uVQ3JEYAbqapM+XyRKFy2Thej7bIw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -18650,7 +18662,7 @@
       "version": "8.18.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
       "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "cli": "tsx cli/index.ts"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.69",
+    "@ai-sdk/openai": "^3.0.52",
     "@as-integrations/next": "^4.1.0",
     "@aws-sdk/client-s3": "^3.772.0",
     "@aws-sdk/s3-request-presigner": "^3.1016.0",
@@ -29,7 +31,7 @@
     "@upstash/redis": "^1.36.3",
     "@vercel/speed-insights": "^2.0.0",
     "@welldone-software/why-did-you-render": "^10.0.1",
-    "ai": "^5.0.50",
+    "ai": "^6.0.158",
     "body-parser": "^1.20.3",
     "booqs-epub": "^1.1.2",
     "clipboard-polyfill": "^4.1.1",
@@ -56,7 +58,6 @@
     "lru-cache": "^11.2.7",
     "nanoid": "^5.1.5",
     "next": "^16.1.6",
-    "openai": "^5.10.2",
     "postcss": "^8.5.3",
     "postcss-prefix-selector": "^2.1.1",
     "postcss-selector-parser": "^7.1.0",


### PR DESCRIPTION
Replace direct OpenAI SDK usage with Vercel AI SDK's generateText/streamText, enabling provider switching via AI_PROVIDER env var (openai | anthropic).